### PR TITLE
Use six.callable for compatibility with Python 3.1

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -187,7 +187,7 @@ class BaseColumn(np.ndarray):
         if obj is None:
             return
 
-        if callable(super(BaseColumn, self).__array_finalize__):
+        if six.callable(super(BaseColumn, self).__array_finalize__):
             super(BaseColumn, self).__array_finalize__(obj)
 
         # Self was created from template (e.g. obj[slice] or (obj * 2))


### PR DESCRIPTION
I think this will resolve the Jenkins failures.
