### PR TITLE
For single columns, store standard info on Column.

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -544,6 +544,10 @@ class Latitude(Angle):
         return _no_angle_subclass(results)
 
 
+class LongitudeInfo(u.QuantityInfo):
+    _represent_as_dict_info_attrs = ['unit', 'wrap_angle']
+
+
 class Longitude(Angle):
     """
     Longitude-like angle(s) which are wrapped within a contiguous 360 degree range.
@@ -601,6 +605,7 @@ class Longitude(Angle):
 
     _wrap_angle = None
     _default_wrap_angle = Angle(360 * u.deg)
+    info = LongitudeInfo()
 
     def __new__(cls, angle, unit=None, wrap_angle=None, **kwargs):
         # Forbid creating a Long from a Lat.

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -545,7 +545,7 @@ class Latitude(Angle):
 
 
 class LongitudeInfo(u.QuantityInfo):
-    _represent_as_dict_info_attrs = ['unit', 'wrap_angle']
+    _represent_as_dict_attrs = u.QuantityInfo._represent_as_dict_attrs + ('wrap_angle',)
 
 
 class Longitude(Angle):

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -8,7 +8,7 @@ import json
 
 import numpy as np
 from .. import units as u
-from ..units.quantity import QuantityInfo
+from ..units.quantity import QuantityInfoBase
 from ..extern import six
 from ..extern.six.moves import urllib
 from ..utils.exceptions import AstropyUserWarning
@@ -83,7 +83,7 @@ def _get_json_result(url, err_str):
     return results
 
 
-class EarthLocationInfo(QuantityInfo):
+class EarthLocationInfo(QuantityInfoBase):
     """
     Container for meta information like name, description, format.  This is
     required when the object is used as a mixin column within a table, but can
@@ -97,6 +97,54 @@ class EarthLocationInfo(QuantityInfo):
         ellipsoid = map.pop('ellipsoid')
         out = self._parent_cls(**map)
         out.ellipsoid = ellipsoid
+        return out
+
+    def new_like(self, cols, length, metadata_conflicts='warn', name=None):
+        """
+        Return a new EarthLocation instance which is consistent with the
+        input ``cols`` and has ``length`` rows.
+
+        This is intended for creating an empty column object whose elements can
+        be set in-place for table operations like join or vstack.
+
+        Parameters
+        ----------
+        cols : list
+            List of input columns
+        length : int
+            Length of the output column object
+        metadata_conflicts : str ('warn'|'error'|'silent')
+            How to handle metadata conflicts
+        name : str
+            Output column name
+
+        Returns
+        -------
+        col : EarthLocation (or subclass)
+            Empty instance of this class consistent with ``cols``
+        """
+        # Very similar to QuantityInfo.new_like, but the creation of the
+        # map is different enough that this needs its own rouinte.
+        # Get merged info attributes shape, dtype, format, description.
+        attrs = self.merge_cols_attributes(cols, metadata_conflicts, name,
+                                           ('meta', 'format', 'description'))
+        # The above raises an error if the dtypes do not match, but returns
+        # just the string representation, which is not useful, so remove.
+        attrs.pop('dtype')
+        # Make empty EarthLocation using the dtype and unit of the last column.
+        # Use zeros so we do not get problems for possible conversion to
+        # geodetic coordinates.
+        shape = (length,) + attrs.pop('shape')
+        data = u.Quantity(np.zeros(shape=shape, dtype=cols[0].dtype),
+                          unit=cols[0].unit, copy=False)
+        # Get arguments needed to reconstruct class
+        map = {key: (data[key] if key in 'xyz' else getattr(cols[-1], key))
+               for key in self._represent_as_dict_attrs}
+        out = self._construct_from_dict(map)
+        # Set remaining info attributes
+        for attr, value in attrs.items():
+            setattr(out.info, attr, value)
+
         return out
 
 
@@ -133,6 +181,10 @@ class EarthLocation(u.Quantity):
     info = EarthLocationInfo()
 
     def __new__(cls, *args, **kwargs):
+        # TODO: needs copy argument and better dealing with inputs.
+        if (len(args) == 1 and len(kwargs) == 0 and
+                isinstance(args[0], EarthLocation)):
+            return args[0].copy()
         try:
             self = cls.from_geocentric(*args, **kwargs)
         except (u.UnitsError, TypeError) as exc_geocentric:

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -89,8 +89,7 @@ class EarthLocationInfo(QuantityInfo):
     required when the object is used as a mixin column within a table, but can
     be used as a general way to store meta information.
     """
-    _represent_as_dict_data_attrs = ['x', 'y', 'z']
-    _represent_as_dict_info_attrs = ['ellipsoid']
+    _represent_as_dict_attrs = ('x', 'y', 'z', 'ellipsoid')
 
     def _construct_from_dict(self, map):
         # Need to pop ellipsoid off and update post-instantiation.  This is

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -72,15 +72,14 @@ class SkyCoordInfo(MixinInfo):
 
     def _represent_as_dict(self):
         obj = self._parent
-        data_attrs = list(obj.representation_component_names)
+        attrs = (list(obj.representation_component_names) +
+                 list(frame_transform_graph.frame_attributes.keys()))
 
         # Don't output distance if it is all unitless 1.0
-        if 'distance' in data_attrs and np.all(obj.distance == 1.0):
-            data_attrs.remove('distance')
+        if 'distance' in attrs and np.all(obj.distance == 1.0):
+            attrs.remove('distance')
 
-        info_attrs = list(frame_transform_graph.frame_attributes)
-        self._represent_as_dict_data_attrs = data_attrs
-        self._represent_as_dict_info_attrs = info_attrs
+        self._represent_as_dict_attrs = attrs
 
         out = super(SkyCoordInfo, self)._represent_as_dict()
 

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -266,7 +266,7 @@ mixin_cols = {
                     obstime=['J1990.5'] * 2),
     'q': [1, 2] * u.m,
     'lat': Latitude([1, 2] * u.deg),
-    'lon': Longitude([1, 2] * u.deg),
+    'lon': Longitude([1, 2] * u.deg, wrap_angle=180.*u.deg),
     'ang': Angle([1, 2] * u.deg),
     'el': el,
     # 'nd': NdarrayMixin(el)  # not supported yet
@@ -333,7 +333,7 @@ def test_ecsv_mixins_per_column(table_cls, name_col):
         'scc': ['x', 'y', 'z', 'representation', 'frame.name'],
         'scd': ['ra', 'dec', 'distance', 'representation', 'frame.name'],
         'q': ['value', 'unit'],
-        'lon': ['value', 'unit'],
+        'lon': ['value', 'unit', 'wrap_angle'],
         'lat': ['value', 'unit'],
         'ang': ['value', 'unit'],
         'el': ['x', 'y', 'z', 'ellipsoid'],

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -297,10 +297,8 @@ def test_ecsv_mixins_as_one(table_cls):
         # For Table, EarthLocation turns into NdarrayMixin, which is
         # not yet supported. Just skip this for now.
         names.remove('el')
-        serialized_names = serialized_names[:2] + serialized_names[5:-3]
-        mixin_cols['tm3'].location = el[0]
-    else:
-        mixin_cols['tm3'].location = el
+        for name in 'el.x', 'el.y', 'el.z':
+            serialized_names.remove(name)
 
     t = table_cls([mixin_cols[name] for name in names], names=names)
 

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -293,12 +293,6 @@ def test_ecsv_mixins_as_one(table_cls):
                         'tm2',  # serialize_method is formatted_value
                         'tm3.jd1', 'tm3.jd2',    # serialize is jd1_jd2
                         'tm3.location.x', 'tm3.location.y', 'tm3.location.z']
-    if table_cls is Table:
-        # For Table, EarthLocation turns into NdarrayMixin, which is
-        # not yet supported. Just skip this for now.
-        names.remove('el')
-        for name in 'el.x', 'el.y', 'el.z':
-            serialized_names.remove(name)
 
     t = table_cls([mixin_cols[name] for name in names], names=names)
 

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -55,8 +55,7 @@ def _represent_mixin_as_column(col, name, new_cols, mixin_cols):
             info[attr] = xform(col_attr) if xform else col_attr
 
     obj_attrs = col.info._represent_as_dict()
-    ordered_keys = (col.info._represent_as_dict_data_attrs +
-                    col.info._represent_as_dict_info_attrs)
+    ordered_keys = col.info._represent_as_dict_attrs
 
     data_attrs = [key for key in ordered_keys if key in obj_attrs and
                   getattr(obj_attrs[key], 'shape', ())[:1] == col.shape[:1]]

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -13,6 +13,7 @@ __construct_mixin_classes = ('astropy.time.core.Time',
                              'astropy.coordinates.angles.Latitude',
                              'astropy.coordinates.angles.Longitude',
                              'astropy.coordinates.angles.Angle',
+                             'astropy.coordinates.distances.Distance',
                              'astropy.coordinates.earth.EarthLocation',
                              'astropy.coordinates.sky_coordinate.SkyCoord',
                              'astropy.table.table.NdarrayMixin')
@@ -30,6 +31,75 @@ class SerializedColumn(dict):
     pass
 
 
+def _represent_mixin_as_column(col, name, new_cols, mixin_cols):
+    """Convert a mixin column to a plain columns or a set of mixin columns."""
+    if not has_info_class(col, MixinInfo):
+        new_cols.append(col)
+        return
+
+    # Subtlety here is handling mixin info attributes.  The basic list of such
+    # attributes is: 'name', 'unit', 'dtype', 'format', 'description', 'meta'.
+    # - name: handled directly [DON'T store]
+    # - unit: DON'T store if this is a parent attribute
+    # - dtype: captured in plain Column if relevant [DON'T store]
+    # - format: possibly irrelevant but settable post-object creation [DO store]
+    # - description: DO store
+    # - meta: DO store
+    info = {}
+    for attr, nontrivial, xform in (('unit', lambda x: x not in (None, ''), str),
+                                    ('format', lambda x: x is not None, None),
+                                    ('description', lambda x: x is not None, None),
+                                    ('meta', lambda x: x, None)):
+        col_attr = getattr(col.info, attr)
+        if nontrivial(col_attr):
+            info[attr] = xform(col_attr) if xform else col_attr
+
+    obj_attrs = col.info._represent_as_dict()
+    ordered_keys = (col.info._represent_as_dict_data_attrs +
+                    col.info._represent_as_dict_info_attrs)
+
+    data_attrs = [key for key in ordered_keys if key in obj_attrs and
+                  getattr(obj_attrs[key], 'shape', ())[:1] == col.shape[:1]]
+
+    for data_attr in data_attrs:
+        data = obj_attrs[data_attr]
+        if len(data_attrs) == 1 and not has_info_class(data, MixinInfo):
+            # For one non-mixin attribute, we need only one serialized column.
+            # We can store info there, and keep the column name as is.
+            new_cols.append(Column(data, name=name, **info))
+            obj_attrs[data_attr] = SerializedColumn({'name': name})
+            # Remove attributes that are already on the serialized column.
+            for attr in info:
+                if attr in obj_attrs:
+                    del obj_attrs[attr]
+
+        else:
+            # New column name combines the old name and attribute
+            # (e.g. skycoord.ra, skycoord.dec).
+            new_name = name + '.' + data_attr
+            # TODO masking, MaskedColumn
+            if not has_info_class(data, MixinInfo):
+                new_cols.append(Column(data, name=new_name))
+                obj_attrs[data_attr] = SerializedColumn({'name': new_name})
+            else:
+                # recurse. This will define obj_attrs[new_name].
+                _represent_mixin_as_column(data, new_name, new_cols, obj_attrs)
+                obj_attrs[data_attr] = SerializedColumn(obj_attrs.pop(new_name))
+
+            # Strip out from info any attributes defined by the parent
+            for attr in col.info.attrs_from_parent:
+                if attr in info:
+                    del info[attr]
+
+            if info:
+                obj_attrs['__info__'] = info
+
+    # Store the fully qualified class name
+    obj_attrs['__class__'] = col.__module__ + '.' + col.__class__.__name__
+
+    mixin_cols[name] = obj_attrs
+
+
 def _represent_mixins_as_columns(tbl):
     """
     Convert any mixin columns to plain Column or MaskedColumn and
@@ -42,69 +112,8 @@ def _represent_mixins_as_columns(tbl):
 
     new_cols = []
 
-    # Subtlety here is handling mixin info attributes.  The basic list of such
-    # attributes is: 'name', 'unit', 'dtype', 'format', 'description', 'meta'.
-    # - name: handled at the top level [DON'T store]
-    # - unit: DON'T store if this is a parent attribute
-    # - dtype: captured in plain Column if relevant [DON'T store]
-    # - format: possibly irrelevant but settable post-object creation [DO store]
-    # - description: DO store
-    # - meta: DO store
-
     for col in tbl.itercols():
-        if not has_info_class(col, MixinInfo):
-            new_cols.append(col)
-        else:
-            obj_attrs = col.info._represent_as_dict()
-            data_attrs = col.info._represent_as_dict_data_attrs
-
-            # Set the __info__ attributes (see long note above)
-            info = {}
-            for attr, nontrivial, xform in (('unit', lambda x: x not in (None, ''), str),
-                                            ('format', lambda x: x is not None, None),
-                                            ('description', lambda x: x is not None, None),
-                                            ('meta', lambda x: x, None)):
-                col_attr = getattr(col.info, attr)
-                if nontrivial(col_attr):
-                    info[attr] = xform(col_attr) if xform else col_attr
-
-            for data_attr in data_attrs:
-                data = obj_attrs[data_attr]
-
-                name = col.info.name
-                # New column name is the same as original if there is only one
-                # data attribute (e.g. time.value), otherwise make a new name
-                # (e.g. skycoord.ra, skycoord.dec).
-                #
-                # In the single-name case the mixin Info gets put into the new
-                # Column so the ECSV header looks complete (and for back compatibility
-                # with pre-2.0 behavior).  However, these are ignored in object
-                # construction later in favor of values in the
-                # __mixin_columns__['__info__'] dict.  This is because in general
-                # object constructors don't pay attention to the .info attributes
-                # in the input data args (e.g. Quantity(col) does look at the unit
-                # but not info.description).
-                if len(data_attrs) > 1:
-                    name = name + '.' + data_attr
-                    col_info = {}
-                else:
-                    col_info = info
-                new_cols.append(Column(data, name=name, **col_info))  # TODO masking, MaskedColumn
-
-                obj_attrs[data_attr] = SerializedColumn({'name': name})
-
-            # Store the fully qualified class name
-            obj_attrs['__class__'] = col.__module__ + '.' + col.__class__.__name__
-
-            # Strip out any attributes defined by the parent
-            for attr in col.info.attrs_from_parent:
-                if attr in info:
-                    del info[attr]
-
-            if info:
-                obj_attrs['__info__'] = info
-
-            mixin_cols[col.info.name] = obj_attrs
+        _represent_mixin_as_column(col, col.info.name, new_cols, mixin_cols)
 
     meta = deepcopy(tbl.meta)
     meta['__mixin_columns__'] = mixin_cols
@@ -113,7 +122,7 @@ def _represent_mixins_as_columns(tbl):
     return out
 
 
-def _construct_mixin_from_obj_attrs(obj_attrs):
+def _construct_mixin_from_obj_attrs_and_info(obj_attrs, info):
     cls_full_name = obj_attrs.pop('__class__')
 
     # If this is a supported class then import the class and run
@@ -125,7 +134,57 @@ def _construct_mixin_from_obj_attrs(obj_attrs):
     mod_name, cls_name = re.match(r'(.+)\.(\w+)', cls_full_name).groups()
     module = import_module(mod_name)
     cls = getattr(module, cls_name)
-    return cls.info._construct_from_dict(obj_attrs)
+    for attr, value in info.items():
+        if attr in cls.info.attrs_from_parent:
+            obj_attrs[attr] = value
+    mixin = cls.info._construct_from_dict(obj_attrs)
+    for attr, value in info.items():
+        if attr not in obj_attrs:
+            setattr(mixin.info, attr, value)
+    return mixin
+
+
+def _construct_mixin_from_columns(new_name, obj_attrs, out):
+    data_attrs_map = {}
+    for name, val in obj_attrs.items():
+        if isinstance(val, SerializedColumn):
+            if 'name' in val:
+                data_attrs_map[val['name']] = name
+            else:
+                _construct_mixin_from_columns(name, val, out)
+                data_attrs_map[name] = name
+
+    for name in data_attrs_map.values():
+        del obj_attrs[name]
+
+    # Get the index where to add new column
+    idx = min(out.colnames.index(name) for name in data_attrs_map)
+
+    # Name is the column name in the table (e.g. "coord.ra") and
+    # data_attr is the object attribute name  (e.g. "ra").  A different
+    # example would be a formatted time object that would have (e.g.)
+    # "time_col" and "value", respectively.
+    for name, data_attr in data_attrs_map.items():
+        col = out[name]
+        obj_attrs[data_attr] = col
+        del out[name]
+
+    if len(data_attrs_map) == 1:
+        # col is the first and only column.
+        info = {}
+        for attr, nontrivial in (('unit', lambda x: x not in (None, '')),
+                                 ('format', lambda x: x is not None),
+                                 ('description', lambda x: x is not None),
+                                 ('meta', lambda x: x)):
+            col_attr = getattr(col.info, attr)
+            if nontrivial(col_attr):
+                info[attr] = col_attr
+    else:
+        info = obj_attrs.pop('__info__', {})
+
+    info['name'] = new_name
+    col = _construct_mixin_from_obj_attrs_and_info(obj_attrs, info)
+    out.add_column(col, index=idx)
 
 
 def _construct_mixins_from_columns(tbl):
@@ -137,30 +196,6 @@ def _construct_mixins_from_columns(tbl):
     mixin_cols = out.meta.pop('__mixin_columns__')
 
     for new_name, obj_attrs in mixin_cols.items():
-        data_attrs_map = {}
-        for name, val in obj_attrs.items():
-            if isinstance(val, SerializedColumn):
-                data_attrs_map[val['name']] = name
-
-        for name in data_attrs_map.values():
-            del obj_attrs[name]
-
-        # Get the index where to add new column
-        idx = min(out.colnames.index(name) for name in data_attrs_map)
-
-        # Name is the column name in the table (e.g. "coord.ra") and
-        # data_attr is the object attribute name  (e.g. "ra").  A different
-        # example would be a formatted time object that would have (e.g.)
-        # "time_col" and "value", respectively.
-        for name, data_attr in data_attrs_map.items():
-            obj_attrs[data_attr] = out[name]
-            del out[name]
-
-        info = obj_attrs.pop('__info__', {})
-        col = _construct_mixin_from_obj_attrs(obj_attrs)
-        col.info.name = new_name
-        for name, value in info.items():
-            setattr(col.info, name, value)
-        out.add_column(col, index=idx)
+        _construct_mixin_from_columns(new_name, obj_attrs, out)
 
     return out

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -16,7 +16,7 @@ from numpy import ma
 
 from .. import log
 from ..io import registry as io_registry
-from ..units import Quantity
+from ..units import Quantity, QuantityInfo
 from ..utils import isiterable, ShapedLikeNDArray
 from ..utils.compat.numpy import broadcast_to as np_broadcast_to
 from ..utils.console import color_print
@@ -902,7 +902,7 @@ class Table(object):
 
         # Is it a mixin but not not Quantity (which gets converted to Column with
         # unit set).
-        return has_info_class(col, MixinInfo) and not isinstance(col, Quantity)
+        return has_info_class(col, MixinInfo) and not has_info_class(col, QuantityInfo)
 
     def pprint(self, max_lines=None, max_width=None, show_name=True,
                show_unit=None, show_dtype=False, align=None):

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -139,6 +139,9 @@ def table_type(request):
 # Stuff for testing mixin columns
 
 MIXIN_COLS = {'quantity': [0, 1, 2, 3] * u.m,
+              'longitude' : coordinates.Longitude([0., 1., 5., 6.]*u.deg,
+                                                  wrap_angle=180.*u.deg),
+              'latitude' : coordinates.Latitude([5., 6., 10., 11.]*u.deg),
               'time': time.Time([2000, 2001, 2002, 2003], format='jyear'),
               'skycoord': coordinates.SkyCoord(ra=[0, 1, 2, 3] * u.deg,
                                                dec=[0, 1, 2, 3] * u.deg),

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -149,6 +149,10 @@ MIXIN_COLS = {'quantity': [0, 1, 2, 3] * u.m,
               'ndarray': np.array([(7, 'a'), (8, 'b'), (9, 'c'), (9, 'c')],
                            dtype='<i4,|S1').view(table.NdarrayMixin),
               }
+MIXIN_COLS['earthlocation'] = coordinates.EarthLocation(
+    lon=MIXIN_COLS['longitude'], lat=MIXIN_COLS['latitude'],
+    height=MIXIN_COLS['quantity'])
+
 
 @pytest.fixture(params=sorted(MIXIN_COLS))
 def mixin_cols(request):

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -63,7 +63,10 @@ def test_attributes(mixin_cols):
 
 
 def check_mixin_type(table, table_col, in_col):
-    if ((isinstance(in_col, u.Quantity) and type(table) is not QTable)
+    # We check for QuantityInfo rather than just isinstance(col, u.Quantity)
+    # since we want to treat EarthLocation as a mixin, even though it is
+    # a Quantity subclass.
+    if ((isinstance(in_col.info, u.QuantityInfo) and type(table) is not QTable)
             or isinstance(in_col, Column)):
         assert type(table_col) is table.ColumnClass
     else:
@@ -239,7 +242,7 @@ def assert_table_name_col_equal(t, name, col):
         assert np.all(t[name].dec == col.dec)
     elif isinstance(col, u.Quantity):
         if type(t) is QTable:
-            assert np.all(t[name].value == col.value)
+            assert np.all(t[name] == col)
     elif isinstance(col, table_helpers.ArrayWrapper):
         assert np.all(t[name].data == col.data)
     else:

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -770,7 +770,8 @@ class TestVStack():
 
         # Vstack works for these classes:
         implemented_mixin_classes = ['Quantity', 'Angle',
-                                     'Latitude', 'Longitude']
+                                     'Latitude', 'Longitude',
+                                     'EarthLocation']
         if cls_name in implemented_mixin_classes:
             table.vstack([t, t])
         else:

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -769,7 +769,8 @@ class TestVStack():
         cls_name = type(col).__name__
 
         # Vstack works for these classes:
-        implemented_mixin_classes = ['Quantity']
+        implemented_mixin_classes = ['Quantity', 'Angle',
+                                     'Latitude', 'Longitude']
         if cls_name in implemented_mixin_classes:
             table.vstack([t, t])
         else:

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -174,9 +174,15 @@ class QuantityInfo(ParentDtypeInfo):
         # Make an empty quantity using the unit of the last one.
         shape = (length,) + attrs.pop('shape')
         dtype = attrs.pop('dtype')
-        data = np.empty(shape=shape, dtype=dtype)
-        unit = cols[-1].unit
-        out = self._parent_cls(data, unit=unit, copy=False)
+        # Use zeros so we do not get problems for Quantity subclasses such
+        # as Longitude and Latitude, which cannot take arbitrary values.
+        data = np.zeros(shape=shape, dtype=dtype)
+        # Get arguments needed to reconstruct class
+        map = {key: (data if key == 'value' else getattr(cols[-1], key))
+               for key in (self._represent_as_dict_data_attrs +
+                           self._represent_as_dict_info_attrs)}
+        map['copy'] = False
+        out = self._construct_from_dict(map)
 
         # Set remaining info attributes
         for attr, value in attrs.items():

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -112,10 +112,9 @@ class QuantityInfo(ParentDtypeInfo):
     required when the object is used as a mixin column within a table, but can
     be used as a general way to store meta information.
     """
-    attrs_from_parent = set(['dtype', 'unit'])  # dtype and unit taken from parent
+    attrs_from_parent = {'dtype', 'unit'}  # dtype and unit taken from parent
     _supports_indexing = True
-    _represent_as_dict_data_attrs = ['value']
-    _represent_as_dict_info_attrs = ['unit']
+    _represent_as_dict_attrs = ('value', 'unit')
 
     @staticmethod
     def default_format(val):
@@ -179,8 +178,7 @@ class QuantityInfo(ParentDtypeInfo):
         data = np.zeros(shape=shape, dtype=dtype)
         # Get arguments needed to reconstruct class
         map = {key: (data if key == 'value' else getattr(cols[-1], key))
-               for key in (self._represent_as_dict_data_attrs +
-                           self._represent_as_dict_info_attrs)}
+               for key in self._represent_as_dict_attrs}
         map['copy'] = False
         out = self._construct_from_dict(map)
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -32,7 +32,8 @@ from .. import config as _config
 from .quantity_helper import (converters_and_unit, can_have_arbitrary_unit,
                               check_output)
 
-__all__ = ["Quantity", "SpecificTypeQuantity", "QuantityInfo"]
+__all__ = ["Quantity", "SpecificTypeQuantity",
+           "QuantityInfoBase", "QuantityInfo"]
 
 
 # We don't want to run doctests in the docstrings we inherit from Numpy
@@ -106,15 +107,12 @@ class QuantityIterator(object):
     next = __next__
 
 
-class QuantityInfo(ParentDtypeInfo):
-    """
-    Container for meta information like name, description, format.  This is
-    required when the object is used as a mixin column within a table, but can
-    be used as a general way to store meta information.
-    """
+class QuantityInfoBase(ParentDtypeInfo):
+    # This is on a base class rather than QuantityInfo directly, so that
+    # it can be used for EarthLocationInfo yet make clear that that class
+    # should not be considered a typical Quantity subclass by Table.
     attrs_from_parent = {'dtype', 'unit'}  # dtype and unit taken from parent
     _supports_indexing = True
-    _represent_as_dict_attrs = ('value', 'unit')
 
     @staticmethod
     def default_format(val):
@@ -133,6 +131,15 @@ class QuantityInfo(ParentDtypeInfo):
         yield lambda format_, val: format(val.value, format_)
         yield lambda format_, val: format_.format(val.value)
         yield lambda format_, val: format_ % val.value
+
+
+class QuantityInfo(QuantityInfoBase):
+    """
+    Container for meta information like name, description, format.  This is
+    required when the object is used as a mixin column within a table, but can
+    be used as a general way to store meta information.
+    """
+    _represent_as_dict_attrs = ('value', 'unit')
 
     def _construct_from_dict(self, map):
         # Need to pop value because different Quantity subclasses use

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -210,8 +210,7 @@ class DataInfo(object):
     attr_names = set(['name', 'unit', 'dtype', 'format', 'description', 'meta'])
     _attrs_no_copy = set()
     _info_summary_attrs = ('dtype', 'shape', 'unit', 'format', 'description', 'class')
-    _represent_as_dict_data_attrs = []
-    _represent_as_dict_info_attrs = []
+    _represent_as_dict_attrs = ()
     _parent = None
 
     def __init__(self, bound=False):
@@ -305,13 +304,8 @@ class DataInfo(object):
         self._attrs[attr] = value
 
     def _represent_as_dict(self):
-        """
-        Get the values for the parent ``attrs`` and return as a dict.
-        """
-        attrs = self._represent_as_dict_data_attrs + self._represent_as_dict_info_attrs
-        out = _get_obj_attrs_map(self._parent, attrs)
-
-        return out
+        """Get the values for the parent ``attrs`` and return as a dict."""
+        return _get_obj_attrs_map(self._parent, self._represent_as_dict_attrs)
 
     def _construct_from_dict(self, map):
         return self._parent_cls(**map)


### PR DESCRIPTION
Really only to see whether it would work -- implemented too crappily to suggest using it directly. But with this, e.g.,
```
# %ECSV 0.9
# ---
# datatype:
# - {name: q, unit: m, datatype: float64, description: bla}
# meta: !!omap
# - __mixin_columns__:
#     q:
#       __class__: astropy.units.quantity.Quantity
#       value: !astropy.table.SerializedColumn {name: q}
```
I'm slightly wondering whether for single columns one could not just as well directly go through `SerializedColumn`, i.e., that this would be
```
q: !astropy.table.SerializedColumn {__class__: astropy.units.quantity.Quantity}
```
(name is obvious; `value` would be implied). That would certainly solve the annoying `if` statements in the current crappy implementation.

With that, I think it would also extend naturally to `jd1` (class `ndarray`), and any regular `dict` would mean a level of recursion to get the `SerializedColumn` out (or another dict, and another level of recursion).

Anyway, really too tired -- I should have gone to sleep hours ago -- but this is very nice and I couldn't resist playing with it!