### PR TITLE
Fix bug when slicing a table with a multi-col index

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1530,6 +1530,7 @@ class Table:
         table.primary_key = self.primary_key
 
         newcols = []
+        new_indices = {}
         for col in self.columns.values():
             newcol = col[slice_]
 
@@ -1542,6 +1543,16 @@ class Table:
                 # Why isn't that just sent as an arg to the function?
                 col.info._copy_indices = self._copy_indices
                 newcol = col.info.slice_indices(newcol, slice_, len(col))
+
+                # The line above (unfortunately) makes a new *independent* index in each
+                # column for a multi-column index. This causes confusion later in
+                # Table.indices since that property checks for object uniqueness of each
+                # index. The root cause of making new independent indices should be
+                # fixed but this is not so easy. Since this is a less-common case, for
+                # now we do a post-facto fix of simply forcing indices to be one object,
+                # namely the first instance encountered in processing, keyed by id.
+                for ii, index in enumerate(newcol.info.indices):
+                    newcol.info.indices[ii] = new_indices.setdefault(index.id, index)
 
                 # Don't understand why this is forcing a value on the original column.
                 # Normally col.info does not even have a _copy_indices attribute.  Tests

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -798,3 +798,19 @@ def test_slice_an_indexed_table(index_first):
         "  0   g    1",
         "  1   b    2>>",
     ]
+
+
+def test_unique_indices_after_multicol_index_slice():
+    """Test that table indices after slicing are correct.
+
+    This tests code in Table._new_from_slice() that ensures uniqueness of table index
+    objects when slicing (via slice, ndarray, list etc) a table with a multi-column
+    index.
+    """
+    t = Table()
+    t["a"] = [2, 3]
+    t["b"] = [3, 5]
+    t.add_index(["a", "b"])
+    t2 = t[:1]
+    assert len(t2.indices) == 1  # without fix would be 2, both with id ("a", "b").
+    assert t2.indices[0].id == ("a", "b")


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to fix a bug when slicing a table that has a multi-column index.

In `Table._new_from_slice`, the line `newcol = col.info.slice_indices(newcol, slice_, len(col))`
makes a new *independent* index in each column for a multi-column index. This causes confusion later in `Table.indices` since that property checks for object uniqueness of each index. The root cause of making new independent indices should be fixed but this is not so easy. Since this is a less-common case, for now we do a post-facto fix of simply forcing indices to be one object, namely the first instance encountered in processing, keyed by id.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
